### PR TITLE
Moving polyzygotic twin from under monozygotic twin fixes #15

### DIFF
--- a/src/main/resources/kin.owl
+++ b/src/main/resources/kin.owl
@@ -155,11 +155,12 @@ SymmetricObjectProperty(<http://purl.org/ga4gh/kin.owl#KIN_010>)
 TransitiveObjectProperty(<http://purl.org/ga4gh/kin.owl#KIN_010>)
 ObjectPropertyDomain(<http://purl.org/ga4gh/kin.owl#KIN_010> <http://purl.org/ga4gh/kin.owl#KIN_998>)
 ObjectPropertyRange(<http://purl.org/ga4gh/kin.owl#KIN_010> <http://purl.org/ga4gh/kin.owl#KIN_998>)
+DisjointObjectProperties(<http://purl.org/ga4gh/kin.owl#KIN_010> <http://purl.org/ga4gh/kin.owl#KIN_011>)
 
 # Object Property: <http://purl.org/ga4gh/kin.owl#KIN_011> (isPolyzygoticTwin)
 
 AnnotationAssertion(rdfs:label <http://purl.org/ga4gh/kin.owl#KIN_011> "isPolyzygoticTwin")
-SubObjectPropertyOf(<http://purl.org/ga4gh/kin.owl#KIN_011> <http://purl.org/ga4gh/kin.owl#KIN_010>)
+SubObjectPropertyOf(<http://purl.org/ga4gh/kin.owl#KIN_011> <http://purl.org/ga4gh/kin.owl#KIN_009>)
 SymmetricObjectProperty(<http://purl.org/ga4gh/kin.owl#KIN_011>)
 TransitiveObjectProperty(<http://purl.org/ga4gh/kin.owl#KIN_011>)
 ObjectPropertyDomain(<http://purl.org/ga4gh/kin.owl#KIN_011> <http://purl.org/ga4gh/kin.owl#KIN_998>)


### PR DESCRIPTION
This PR makes mono and poly zygote siblings

Fixes #15.  

![image](https://user-images.githubusercontent.com/50745/136871541-1535e475-8b18-4d59-964d-7024bff7c520.png)

Note: the PR originally made these disjoint but it looks like it doesn't work to mix disjointness and property chains due to DL restrictions, ideally there would be a PR check for this #18. 